### PR TITLE
[INJIMOB-3730] add support for claim169 mapped encode and decode

### DIFF
--- a/Sources/pixelpass/Cbor.swift
+++ b/Sources/pixelpass/Cbor.swift
@@ -80,42 +80,60 @@ extension CBOR {
 
 func convertToCBOREncodableFormat(input: Any) -> CBOR? {
     switch input {
-    case let array as [Any]:
-        return .array(array.compactMap { convertToCBOREncodableFormat(input: $0) })
-        
-    case let dict as [String: Any]:
+
+    case let dict as [AnyHashable: Any]:
         var map = [CBOR: CBOR]()
         for (key, value) in dict {
-            if let keyCbor = convertToCBOREncodableFormat(input: key),
-               let valueCbor = convertToCBOREncodableFormat(input: value) {
-                map[keyCbor] = valueCbor
-            } else {
-                os_log("Non-encodable key or value encountered: %{PUBLIC}@", log: OSLog.default, type: .error, key)
-            }
+            guard
+                let keyCbor = convertToCBOREncodableFormat(input: key),
+                let valueCbor = convertToCBOREncodableFormat(input: value)
+            else { continue }
+            map[keyCbor] = valueCbor
         }
         return .map(map)
-        
+
+    case let array as [Any]:
+        return .array(array.compactMap {
+            convertToCBOREncodableFormat(input: $0)
+        })
+
+    case let int as Int:
+            if int >= 0 {
+                return .unsignedInt(UInt64(int))
+            } else {
+                let int64 = Int64(int)
+                return .negativeInt(UInt64(-1 - int64))
+            }
+
+    case let uint as UInt:
+        return .unsignedInt(UInt64(uint))
+
+    case let uint64 as UInt64:
+        return .unsignedInt(uint64)
+
     case let string as String:
         return .utf8String(string)
-        
-    case let base64String as String:
-        let data = Data(base64Encoded: base64String)
-        return .byteString([UInt8](data!))
-        
-    case let unsignedInt as UInt64:
-        return .unsignedInt(unsignedInt)
-        
+
     case let bool as Bool:
         return .boolean(bool)
-        
+
     case let double as Double:
         return .double(double)
-        
+
+    case let data as Data:
+        return .byteString([UInt8](data))
+
     case is NSNull:
         return .null
-        
+
     default:
-        os_log("Unhandled or non-encodable JSON type encountered: %{PUBLIC}@", log: OSLog.default, type: .error, String(describing: input))
+        os_log(
+            "Unhandled or non-encodable JSON type encountered: %{PUBLIC}@",
+            log: .default,
+            type: .error,
+            String(describing: input)
+        )
         return nil
     }
 }
+

--- a/Sources/pixelpass/Constants.swift
+++ b/Sources/pixelpass/Constants.swift
@@ -1,5 +1,5 @@
 import Foundation
- struct Constants{
+ public struct Constants{
      static let headerSize = 2
      static let initialBufferSizeMultiplier = 4
      static let extraBufferSize = 8 * 1024
@@ -13,4 +13,169 @@ import Foundation
      
      static let zipHeader = "PK"
      static let defaultZipFileName = "certificate.json"
+     
+     public static let claim169KeyMapper: [String: Int] = [
+         "ID": 1,
+         "Version": 2,
+         "Language": 3,
+         "Full Name": 4,
+         "First Name": 5,
+         "Middle Name": 6,
+         "Last Name": 7,
+         "Date of Birth": 8,
+         "Gender": 9,
+         "Address": 10,
+         "Email ID": 11,
+         "Phone Number": 12,
+         "Nationality": 13,
+         "Marital Status": 14,
+         "Guardian": 15,
+         "Binary Image": 16,
+         "Binary Image Format": 17,
+         "Best Quality Fingers": 18,
+         "Right Thumb": 50,
+         "Right Pointer Finger": 51,
+         "Right Middle Finger": 52,
+         "Right Ring Finger": 53,
+         "Right Little Finger": 54,
+         "Left Thumb": 55,
+         "Left Pointer Finger": 56,
+         "Left Middle Finger": 57,
+         "Left Ring Finger": 58,
+         "Left Little Finger": 59,
+         "Right Iris": 60,
+         "Left Iris": 61,
+         "Face": 62,
+         "Right Palm Print": 63,
+         "Left Palm Print": 64,
+         "Voice": 65,
+         "Data": 0,
+         "Data format": 1,
+         "Data sub format": 2,
+         "Data issuer": 3
+     ]
+     
+     public static let claim169ValueMapper: [String: [AnyHashable: Int]] = [
+         "Data format": [
+             "Image": 0,
+             "Template": 1,
+             "Sound": 2,
+             "Bio Hash": 3
+         ],
+         "Data sub format": [
+             
+             "PNG": 0,
+             "JPEG": 1,
+             "JPEG2000": 2,
+             "AVIF": 3,
+             "WEBP": 4,
+             "TIFF": 5,
+             "WSQ": 6,
+             
+             "Fingerprint Template ANSI 378": 0,
+             "Fingerprint Template ISO 19794-2": 1,
+             "Fingerprint Template NIST": 2,
+
+             "WAV": 0,
+             "MP3": 1
+         ],
+         "Gender": [
+             "Male": 1,
+             "Female": 2,
+             "Others": 3
+         ],
+         "Marital Status": [
+             "Unmarried": 1,
+             "Married": 2,
+             "Divorced": 3
+         ],
+         "Binary Image Format": [
+             "JPEG": 1,
+             "JPEG2": 2,
+             "AVIF": 3,
+             "WEBP": 4
+         ]
+     ]
+
+     
+     public static let claim169ReverseKeyMapper: [[String: String]] = [
+         [
+             "1": "ID",
+             "2": "Version",
+             "3": "Language",
+             "4": "Full Name",
+             "5": "First Name",
+             "6": "Middle Name",
+             "7": "Last Name",
+             "8": "Date of Birth",
+             "9": "Gender",
+             "10": "Address",
+             "11": "Email ID",
+             "12": "Phone Number",
+             "13": "Nationality",
+             "14": "Marital Status",
+             "15": "Guardian",
+             "16": "Binary Image",
+             "17": "Binary Image Format",
+             "18": "Best Quality Fingers",
+             "50": "Right Thumb",
+             "51": "Right Pointer Finger",
+             "52": "Right Middle Finger",
+             "53": "Right Ring Finger",
+             "54": "Right Little Finger",
+             "55": "Left Thumb",
+             "56": "Left Pointer Finger",
+             "57": "Left Middle Finger",
+             "58": "Left Ring Finger",
+             "59": "Left Little Finger",
+             "60": "Right Iris",
+             "61": "Left Iris",
+             "62": "Face",
+             "63": "Right Palm Print",
+             "64": "Left Palm Print",
+             "65": "Voice"
+         ],
+         [
+             "0": "Data",
+             "1": "Data format",
+             "2": "Data sub format",
+             "3": "Data issuer"
+         ]
+     ]
+     
+     static let claim169RootReverseValueMapper: [String: [AnyHashable: String]] = [
+         "Data format": [0: "Image", 1: "Template", 2: "Sound", 3: "Bio Hash"],
+         "Gender": [1: "Male", 2: "Female", 3: "Others"],
+         "Marital Status": [1: "Unmarried", 2: "Married", 3: "Divorced"],
+         "Binary Image Format": [1: "JPEG", 2: "JPEG2", 3: "AVIF", 4: "WEBP"]
+     ]
+
+     static let claim169BiometricKeys = [
+         "Right Thumb", "Right Pointer Finger", "Right Middle Finger", "Right Ring Finger", "Right Little Finger",
+         "Left Thumb", "Left Pointer Finger", "Left Middle Finger", "Left Ring Finger", "Left Little Finger",
+         "Right Iris", "Left Iris", "Face", "Right Palm Print", "Left Palm Print", "Voice"
+     ]
+
+     static let claim169BiometricFormatReverseValueMapper: [AnyHashable: String] = [
+         0: "Image", 1: "Template", 2: "Sound", 3: "Bio Hash"
+     ]
+
+     static let claim169BiometricSubFormatReverseValueMapper: [String: [AnyHashable: String]] = [
+         "Image": [
+             0: "PNG", 1: "JPEG", 2: "JPEG2000", 3: "AVIF", 4: "WEBP", 5: "TIFF", 6: "WSQ"
+         ],
+         "Template": [
+             0: "Fingerprint Template ANSI 378",
+             1: "Fingerprint Template ISO 19794-2",
+             2: "Fingerprint Template NIST"
+         ],
+         "Sound": [
+             0: "WAV", 1: "MP3"
+         ]
+     ]
+
+     static let claim169BiometricDataFormatKey = "Data format"
+     static let claim169BiometricDataSubFormatKey = "Data sub format"
+
+
 }

--- a/Sources/pixelpass/MapperUtils.swift
+++ b/Sources/pixelpass/MapperUtils.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+
+func mapJsonWithKeyAndValueMapper(
+    _ json: [String: Any],
+    keyMapper: [String: Any] = [:],
+    valueMapper: [String: [AnyHashable: Any]] = [:]
+) -> [AnyHashable: Any] {
+
+    let normalizedKeyMapper = normalizeKeyMapper(keyMapper)
+    let normalizedValueMapper = normalizeValueMapper(valueMapper)
+
+    var result: [AnyHashable: Any] = [:]
+
+    for (originalKey, originalValue) in json {
+        let normalizedKey = originalKey.lowercased()
+
+        let mappedKey: AnyHashable =
+        (normalizedKeyMapper[normalizedKey] as? AnyHashable) ?? originalKey as AnyHashable
+
+        let processedValue = processValue(
+            originalValue,
+            fieldKey: normalizedKey,
+            normalizedValueMapper: normalizedValueMapper,
+            keyMapper: keyMapper,
+            valueMapper: valueMapper
+        )
+
+            result[mappedKey] = processedValue
+        
+    }
+
+    return result
+}
+
+func mapArrayWithKeyAndValueMapper(
+    _ array: [Any],
+    keyMapper: [String: Any] = [:],
+    valueMapper: [String: [AnyHashable: Any]] = [:]
+) -> [Any] {
+
+    return array.map { value in
+        processValue(
+            value,
+            fieldKey: nil,
+            normalizedValueMapper: normalizeValueMapper(valueMapper),
+            keyMapper: keyMapper,
+            valueMapper: valueMapper
+        )
+    }
+}
+
+
+private func processValue(
+    _ value: Any,
+    fieldKey: String?,
+    normalizedValueMapper: [String: [AnyHashable: Any]],
+    keyMapper: [String: Any],
+    valueMapper: [String: [AnyHashable: Any]]
+) -> Any {
+
+    if value is NSNull {
+        return NSNull()
+    }
+
+    if let dict = value as? [String: Any] {
+        return mapJsonWithKeyAndValueMapper(
+            dict,
+            keyMapper: keyMapper,
+            valueMapper: valueMapper
+        )
+    }
+
+    if let array = value as? [Any] {
+        return mapArrayWithKeyAndValueMapper(
+            array,
+            keyMapper: keyMapper,
+            valueMapper: valueMapper
+        )
+    }
+
+
+    if let fieldKey = fieldKey,
+       let fieldValueMapper = normalizedValueMapper[fieldKey] {
+
+        let lookupKey: AnyHashable? =
+            (value as? String)?.lowercased() as AnyHashable? ??
+            (value as? AnyHashable)
+
+        if let lookupKey,
+           let mappedValue = fieldValueMapper[lookupKey] {
+            return mappedValue
+        }
+    }
+
+    return value
+}
+
+private func normalizeKeyMapper(_ mapper: [String: Any]) -> [String: Any] {
+    var result: [String: Any] = [:]
+    for (key, value) in mapper {
+        result[key.lowercased()] = value
+    }
+    return result
+}
+
+private func normalizeValueMapper(
+    _ mapper: [String: [AnyHashable: Any]]
+) -> [String: [AnyHashable: Any]] {
+
+    var result: [String: [AnyHashable: Any]] = [:]
+
+    for (fieldKey, valueMap) in mapper {
+        var normalizedValueMap: [AnyHashable: Any] = [:]
+
+        for (valueKey, mappedValue) in valueMap {
+            if let stringKey = valueKey as? String {
+                normalizedValueMap[stringKey.lowercased()] = mappedValue
+            } else {
+                normalizedValueMap[valueKey] = mappedValue
+            }
+        }
+
+        result[fieldKey.lowercased()] = normalizedValueMap
+    }
+
+    return result
+}

--- a/Sources/pixelpass/Utils.swift
+++ b/Sources/pixelpass/Utils.swift
@@ -14,3 +14,104 @@ public func clearTemporaryDirectory() {
     }
 }
 
+public func replaceValuesForClaim169(_ json: [String: Any]) -> [String: Any] {
+    var result = json
+
+    for (field, reverseMap) in Constants.claim169RootReverseValueMapper {
+        if let rawValue = result[field],
+           let normalized = normalize(rawValue),
+           let mapped = reverseMap[normalized] {
+            result[field] = mapped
+        }
+    }
+
+    for biometricKey in Constants.claim169BiometricKeys {
+        guard var biometricData = result[biometricKey] as? [String: Any] else { continue }
+
+        if let rawFormat = biometricData[Constants.claim169BiometricDataFormatKey] {
+            let formatLabel: String?
+
+            if let i = rawFormat as? Int {
+                formatLabel = Constants.claim169BiometricFormatReverseValueMapper[i]
+            } else if let u = rawFormat as? UInt {
+                formatLabel = Constants.claim169BiometricFormatReverseValueMapper[Int(u)]
+            } else if let u64 = rawFormat as? UInt64 {
+                formatLabel = Constants.claim169BiometricFormatReverseValueMapper[Int(u64)]
+            } else {
+                formatLabel = nil
+            }
+
+            if let formatLabel {
+                biometricData[Constants.claim169BiometricDataFormatKey] = formatLabel
+
+                if let rawSub = biometricData[Constants.claim169BiometricDataSubFormatKey],
+                   let subMap = Constants.claim169BiometricSubFormatReverseValueMapper[formatLabel] {
+
+                    if let i = rawSub as? Int, let label = subMap[i] {
+                        biometricData[Constants.claim169BiometricDataSubFormatKey] = label
+                    } else if let u = rawSub as? UInt, let label = subMap[Int(u)] {
+                        biometricData[Constants.claim169BiometricDataSubFormatKey] = label
+                    } else if let u64 = rawSub as? UInt64, let label = subMap[Int(u64)] {
+                        biometricData[Constants.claim169BiometricDataSubFormatKey] = label
+                    }
+                }
+            }
+        }
+
+        result[biometricKey] = biometricData
+    }
+
+
+    return result
+}
+
+func replaceKeysAtDepth(
+    json: Any,
+    mapper: [String: String],
+    targetDepth: Int,
+    currentDepth: Int = 0
+) -> Any {
+    
+    if let dict = json as? [String: Any] {
+        var result: [String: Any] = [:]
+
+        for (key, value) in dict {
+            let newKey: String =
+                (currentDepth == targetDepth) ? (mapper[key] ?? key) : key
+
+            let processedValue: Any = replaceKeysAtDepth(
+                json: value,
+                mapper: mapper,
+                targetDepth: targetDepth,
+                currentDepth: currentDepth + 1
+            )
+            result[newKey] = processedValue
+        }
+        return result
+    }
+
+    
+    if let array = json as? [Any] {
+        return array.map {
+            replaceKeysAtDepth(
+                json: $0,
+                mapper: mapper,
+                targetDepth: targetDepth,
+                currentDepth: currentDepth
+            )
+        }
+    }
+
+    
+    return json
+}
+
+
+func normalize(_ value: Any) -> AnyHashable? {
+    if let str = value as? String {
+        return str.lowercased()
+    }
+    return value as? AnyHashable
+}
+
+

--- a/Sources/pixelpass/pixelpass.swift
+++ b/Sources/pixelpass/pixelpass.swift
@@ -164,6 +164,47 @@ public class PixelPass {
         return cborEncodableData.encode().toHexString()
     }
     
+    public func getMappedData(
+            jsonData: [String: Any],
+            keyMapper: [String: Any] = Constants.claim169KeyMapper,
+            valueMapper: [String: [AnyHashable: Any]] = Constants.claim169ValueMapper,
+            cborEnable: Bool = false
+        ) -> Any {
+
+            let mapped = mapJsonWithKeyAndValueMapper(
+                jsonData,
+                keyMapper: keyMapper,
+                valueMapper: valueMapper
+            )
+
+            if cborEnable {
+                let cbor = convertToCBOREncodableFormat(input: mapped)
+                return cbor.encode().toHexString()
+            }
+
+            return mapped
+        }
+    
+    public func getMappedData(
+        jsonArray: [[String: Any]],
+        keyMapper: [String: Any] = Constants.claim169KeyMapper,
+        valueMapper: [String: [AnyHashable: Any]] = Constants.claim169ValueMapper,
+        cborEnable: Bool = false
+    ) -> [Any] {
+
+        return jsonArray.map {
+            getMappedData(
+                jsonData: $0,
+                keyMapper: keyMapper,
+                valueMapper: valueMapper,
+                cborEnable: cborEnable
+            )
+        }
+    }
+    
+    
+
+    
     public func decodeMappedData(stringData: String, mapper: [String: String]) -> [String: String]? {
         do {
             let data = [UInt8](Data(hexString: stringData) ?? Data())
@@ -186,6 +227,38 @@ public class PixelPass {
             return nil
         }
     }
+    
+    public func decodeMappedData(
+        data: String,
+        keyMapper: [[String: String]] = Constants.claim169ReverseKeyMapper,
+        valueMapper: ([String: Any]) -> [String: Any] = replaceValuesForClaim169
+    ) -> String {
+
+        let json: [String: Any]
+
+        if let bytes = Data(hexString: data),
+           let cbor = try? CBOR.decode([UInt8](bytes)) {
+            json = cbor.converToJsonCompatibleFormat() as? [String: Any] ?? [:]
+        } else {
+            json = (try? JSONSerialization.jsonObject(with: Data(data.utf8))) as? [String: Any] ?? [:]
+        }
+
+        let remappedAny = keyMapper.enumerated().reduce(json as Any) { acc, pair in
+            replaceKeysAtDepth(
+                json: acc,
+                mapper: pair.element,
+                targetDepth: pair.offset
+            )
+        }
+
+        guard let remapped = remappedAny as? [String: Any] else { return "" }
+
+        let final = valueMapper(remapped)
+
+        let encoded = try? JSONSerialization.data(withJSONObject: final, options: [])
+        return encoded.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    }
+
     
     func translateToJSON(jsonData: Data, mapper: [String: String]) -> [String: String] {
         do {
@@ -227,5 +300,20 @@ public class PixelPass {
             throw decodeByteArrayError.customError(description: "error occurred while parsing  data - \(error.localizedDescription)")
         }
     }
+    
+    public func decodeMappedData(
+        dataArray: [String],
+        keyMapper: [[String: String]] = Constants.claim169ReverseKeyMapper,
+        valueMapper: ([String: Any]) -> [String: Any] = replaceValuesForClaim169
+    ) -> [String] {
+        return dataArray.map { item in
+            decodeMappedData(
+                data: item,
+                keyMapper: keyMapper,
+                valueMapper: valueMapper
+            )
+        }
+    }
 }
 #endif
+

--- a/Tests/pixelpassTests/pixelpassTests.swift
+++ b/Tests/pixelpassTests/pixelpassTests.swift
@@ -232,6 +232,361 @@ class PixelPassTests: XCTestCase {
             XCTAssertNotNil(data, "Expected PNG data for ECC level \(level)")
         }
     }
+    
+    func testClaim169Default_ObjectRoundTrip() throws {
+        let originalJson = """
+        {
+          "ID":"102030",
+          "Full Name":"John",
+          "Gender":"Male",
+          "Left Middle Finger":{
+            "Data":"9988",
+            "Data format":"Template",
+            "Data sub format":"Fingerprint Template NIST"
+          }
+        }
+        """
+
+        let jsonObject = try JSONSerialization.jsonObject(
+            with: Data(originalJson.utf8)
+        ) as! [String: Any]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: jsonObject,
+            cborEnable: true
+        ) as! String
+
+        XCTAssertFalse(encoded.isEmpty)
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        
+        XCTAssertEqual(decodedJson["ID"] as? String, "102030")
+        XCTAssertEqual(decodedJson["Full Name"] as? String, "John")
+        XCTAssertEqual(decodedJson["Gender"] as? String, "Male")
+
+        
+        let biometric = decodedJson["Left Middle Finger"] as! [String: Any]
+
+        XCTAssertEqual(biometric["Data"] as? String, "9988")
+        XCTAssertEqual(biometric["Data format"] as? String, "Template")
+        XCTAssertEqual(
+            biometric["Data sub format"] as? String,
+            "Fingerprint Template NIST"
+        )
+    }
+
+    
+    func testClaim169_UsesIntegerKeys() {
+        let json: [String: Any] = [
+            "Full Name": "John Doe",
+            "Gender": "Male"
+        ]
+
+        let mapped = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: false
+        ) as! [AnyHashable: Any]
+
+        XCTAssertTrue(mapped.keys.allSatisfy { $0 is Int })
+    }
+    
+    func testClaim169_MixedKnownAndUnknown_RoundTrip() throws {
+        let json: [String: Any] = [
+            "Full Name": "John Doe",
+            "Issuer Note": "Verified at source"
+        ]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqual(decodedJson["Full Name"] as? String, "John Doe")
+        XCTAssertEqual(decodedJson["Issuer Note"] as? String, "Verified at source")
+    }
+    
+    func testClaim169_ArrayOfObjects_BatchEncodeAndDecode() throws {
+        let json1: [String: Any] = [
+            "Full Name": "John Doe",
+            "Gender": "Male"
+        ]
+
+        let json2: [String: Any] = [
+            "Full Name": "John",
+            "Gender": "Female"
+        ]
+
+        let jsonArray: [[String: Any]] = [
+            json1,
+            json2
+        ]
+
+        let encodedBatch = pixelPass.getMappedData(
+            jsonArray: jsonArray,
+            cborEnable: true
+        ) as! [String]
+
+        XCTAssertEqual(encodedBatch.count, 2)
+        XCTAssertFalse(encodedBatch[0].isEmpty)
+        XCTAssertFalse(encodedBatch[1].isEmpty)
+
+        let decodedBatch = pixelPass.decodeMappedData(
+            dataArray: encodedBatch
+        )
+
+        XCTAssertEqual(decodedBatch.count, 2)
+
+        
+        let decoded1 = try JSONSerialization.jsonObject(
+            with: Data(decodedBatch[0].utf8)
+        ) as! [String: Any]
+
+        let decoded2 = try JSONSerialization.jsonObject(
+            with: Data(decodedBatch[1].utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqual(decoded1["Full Name"] as? String, "John Doe")
+        XCTAssertEqual(decoded1["Gender"] as? String, "Male")
+
+        XCTAssertEqual(decoded2["Full Name"] as? String, "John")
+        XCTAssertEqual(decoded2["Gender"] as? String, "Female")
+    }
+
+    func testClaim169_CBOR_IsDeterministic() {
+        let json: [String: Any] = [
+            "Full Name": "John Doe",
+            "Gender": "Male"
+        ]
+
+        let encoded1 = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let encoded2 = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        XCTAssertEqual(encoded1, encoded2)
+    }
+
+    func testClaim169_EmptyObject_DoesNotEncodeToNull() {
+        let encoded = pixelPass.getMappedData(
+            jsonData: [:],
+            cborEnable: true
+        ) as! String
+
+        XCTAssertNotEqual(encoded.lowercased(), "f6")
+    }
+ 
+    func testClaim169_SingleVsBatchParity() throws {
+        let json: [String: Any] = [
+            "Full Name": "John Doe",
+            "Gender": "Male"
+        ]
+
+        let singleEncoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let batchEncoded = pixelPass.getMappedData(
+            jsonArray: [json],
+            cborEnable: true
+        ) as! [String]
+
+        XCTAssertEqual(batchEncoded.count, 1)
+        XCTAssertEqual(batchEncoded[0], singleEncoded)
+    }
+    
+    func testClaim169_BatchDecode_OrderIsPreserved() throws {
+        let jsonArray: [[String: Any]] = [
+            ["Full Name": "First"],
+            ["Full Name": "Second"],
+            ["Full Name": "Third"]
+        ]
+
+        let encodedBatch = pixelPass.getMappedData(
+            jsonArray: jsonArray,
+            cborEnable: true
+        ) as! [String]
+
+        let decodedBatch = pixelPass.decodeMappedData(
+            dataArray: encodedBatch
+        )
+
+        let decoded0 = try JSONSerialization.jsonObject(
+            with: Data(decodedBatch[0].utf8)
+        ) as! [String: Any]
+
+        let decoded1 = try JSONSerialization.jsonObject(
+            with: Data(decodedBatch[1].utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqual(decoded0["Full Name"] as? String, "First")
+        XCTAssertEqual(decoded1["Full Name"] as? String, "Second")
+    }
+
+    func testClaim169_UnknownEnumValue_Preserved() throws {
+        let json: [String: Any] = [
+            "Gender": "NonBinary"
+        ]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqual(decodedJson["Gender"] as? String, "NonBinary")
+    }
+    
+    func testClaim169_MultipleBiometrics_RoundTrip() throws {
+        let json: [String: Any] = [
+            "ID": "5001",
+            "Right Thumb": [
+                "Data": "AAA",
+                "Data format": "Image",
+                "Data sub format": "PNG"
+            ],
+            "Left Iris": [
+                "Data": "BBB",
+                "Data format": "Image",
+                "Data sub format": "JPEG"
+            ]
+        ]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqualDictionaries(json, decodedJson)
+    }
+    
+    func testClaim169_BiometricWithUnknownNestedFields() throws {
+        let json: [String: Any] = [
+            "Full Name": "Alice",
+            "Face": [
+                "Data": "FACE123",
+                "Data format": "Image",
+                "Data sub format": "JPEG",
+                "Capture Device": "Canon EOS"
+            ]
+        ]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqualDictionaries(json, decodedJson)
+    }
+    
+    
+    func testClaim169_DeepMixedDocument_RoundTrip() throws {
+        let json: [String: Any] = [
+            "ID": "9009",
+            "Version": "1.0",
+            "Language": "en",
+            "Gender": "Female",
+            "Left Thumb": [
+                "Data": "LT123",
+                "Data format": "Template",
+                "Data sub format": "Fingerprint Template ISO 19794-2"
+            ],
+            "Right Iris": [
+                "Data": "RI456",
+                "Data format": "Image",
+                "Data sub format": "JPEG2000"
+            ],
+            "Issuer Note": "Verified manually"
+        ]
+
+        let encoded = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: true
+        ) as! String
+
+        let decoded = pixelPass.decodeMappedData(data: encoded)
+
+        let decodedJson = try JSONSerialization.jsonObject(
+            with: Data(decoded.utf8)
+        ) as! [String: Any]
+
+        XCTAssertEqualDictionaries(json, decodedJson)
+    }
+
+    func testClaim169_MappedOutput_UsesIntegerKeys() {
+        let json = [
+            "Full Name": "John",
+            "Gender": "Male"
+        ]
+
+        let mapped = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: false
+        ) as! [AnyHashable: Any]
+
+        XCTAssertTrue(mapped.keys.allSatisfy { $0 is Int })
+    }
+
+    func testClaim169_MappedOutput_BiometricEnumsAreInts() {
+        let json: [String: Any] = [
+            "Left Thumb": [
+                "Data": "123",
+                "Data format": "Template",
+                "Data sub format": "Fingerprint Template NIST"
+            ]
+        ]
+
+        let mapped = pixelPass.getMappedData(
+            jsonData: json,
+            cborEnable: false
+        ) as! [AnyHashable: Any]
+
+        
+        let bio = mapped[55] as! [AnyHashable: Any]
+
+        XCTAssertTrue(bio[1] is Int)
+
+        XCTAssertTrue(bio[2] is Int)
+
+        XCTAssertEqual(bio[1] as? Int, 1)
+        XCTAssertEqual(bio[2] as? Int, 2)
+    }
+
+
+
 }
 
 func XCTAssertEqualDictionaries(_ expected: [String: Any], _ actual: [String: Any], file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CBOR encoder: supports additional numeric types and binary data, skips non-encodable entries, and handles arrays.
  * Public API for claim169 biometric mapping and normalization, plus flexible recursive key/value mapping utilities.
  * Batch processing and decoding APIs for JSON/CBOR inputs.

* **Tests**
  * Extensive test suite covering mapping, deterministic CBOR encoding, batch operations, and round-trip scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->